### PR TITLE
Clone with HTTPS instead of SSH in Project Setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,14 @@ sudo apt-get install node -y
 ### Project Setup
 
 1. Clone this repo
-```sh
-git clone https://github.com/yashvardhan-kukreja/nail-hacktoberfest.git
-```
+   * With HTTPS
+   ```sh
+   git clone https://github.com/yashvardhan-kukreja/nail-hacktoberfest.git
+   ```
+   * With SSH (just use HTTPS if you aren't sure what SSH is)
+   ```sh
+   git clone git@github.com:yashvardhan-kukreja/nail-hacktoberfest.git
+   ```
 2. Hope into the project directory
 ```sh
 cd nail-hacktoberfest

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ sudo apt-get install node -y
 
 1. Clone this repo
 ```sh
-git clone git@github.com:yashvardhan-kukreja/nail-hacktoberfest.git
+git clone https://github.com/yashvardhan-kukreja/nail-hacktoberfest.git
 ```
 2. Hope into the project directory
 ```sh


### PR DESCRIPTION
I wanted to contribute to this repository by adding some facts. So I followed the steps in the project setup section of README, and immediately found the problem in the first step. I run this command on my computer:
```sh
git clone git@github.com:yashvardhan-kukreja/nail-hacktoberfest.git
```
And then it failed ...
```
Cloning into 'nail-hacktoberfest'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```
I think that's because the repository given in the argument is SSH, which as far as I know it can only be used when you have SSH keys for that repository (correct my if I'm wrong). So I changed it to HTTPS, and it worked!